### PR TITLE
Filter streams without infoHash and include infoHash in stream objects

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -114,21 +114,32 @@ async function searchTorrents(id, options) {
     const seen = new Set();
 
     for (const hit of (data.hits || [])) {
+      const infoHash = [hit.infoHash, hit.infohash, hit.hash]
+        .find(value => typeof value === 'string' && value.trim());
+      if (!infoHash) continue;
+
       const magnet = [hit.magnetUrl, hit.magnetLink]
         .find(value => typeof value === 'string' && value.startsWith('magnet:'));
-      if (!magnet || seen.has(magnet)) continue;
-      seen.add(magnet);
+      const hashKey = infoHash.trim().toLowerCase();
+      if (seen.has(hashKey)) continue;
+      seen.add(hashKey);
 
       const size = formatBytes(hit.bytes);
       const seeds = hit.seeders || 0;
       const src = hit.cachedOrigin || 'Unknown';
       const displayTitle = hit.title || meta.name || 'Unknown';
 
-      streams.push({
+      const stream = {
         name: 'Flix-Finder',
         title: `${displayTitle}\n${size} | S:${seeds} | ${src}`,
-        url: magnet
-      });
+        infoHash: infoHash.trim()
+      };
+
+      if (magnet) {
+        stream.url = magnet;
+      }
+
+      streams.push(stream);
     }
 
     return streams;


### PR DESCRIPTION
### Motivation
- Ensure only results that contain an infohash are forwarded to Stremio so the add-on can reliably reference torrents. 
- Avoid dropping entries that have an `infoHash` but lack a magnet link by deduplicating on hash instead of magnet URL. 
- Preserve magnet URLs when available while still exposing the canonical `infoHash` for clients.

### Description
- Updated `lib/ext.js` to extract an info hash from `hit.infoHash`, `hit.infohash`, or `hit.hash` and skip results that lack one. 
- Changed deduplication to use a lowercased trimmed `infoHash` key instead of the magnet string. 
- Added an `infoHash` field to the produced stream objects and only set `url` when a `magnetUrl`/`magnetLink` is present. 
- Kept the previous display formatting (`title`, size, seeders, source) and added the new `infoHash` to each stream.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4340d2008331a67ab6eff4e950bd)