### PR TITLE
Fix syntax error: use streams.push instead of const stream

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -133,7 +133,7 @@ async function searchTorrents(id, options) {
       const src = hit.cachedOrigin || 'Unknown';
       const displayTitle = hit.title || meta.name || 'Unknown';
 
-      const stream = {
+      streams.push({
         name: 'Flix-Finder',
         title: `${displayTitle}\n${size} | S:${seeds} | ${src}`,
         infoHash: infoHash


### PR DESCRIPTION
The previous merge introduced a bug where "streams.push({" was incorrectly changed to "const stream = {" which caused:
1. A syntax error (object literal ending with ");")
2. Streams never being added to the array

https://claude.ai/code/session_01DLvz4ScvNv2fiqjEnZB9Z3