### PR TITLE
Fix manifest URL format: use base64-encoded config in path

### DIFF
--- a/api/config-manifest.js
+++ b/api/config-manifest.js
@@ -1,0 +1,42 @@
+function decodeConfig(configStr) {
+  if (!configStr) return {};
+  try {
+    const decoded = Buffer.from(configStr, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch {
+    return {};
+  }
+}
+
+const manifest = {
+  id: 'com.stremio.flixfinder',
+  version: '2.0.0',
+  name: 'Flix-Finder',
+  description: 'Find and stream torrents from multiple sources',
+  logo: 'https://raw.githubusercontent.com/Thsandorh/Flix-finder/main/logo.svg',
+  configurable: true,
+  resources: ['stream'],
+  types: ['movie', 'series'],
+  catalogs: [],
+  idPrefixes: ['tt'],
+  behaviorHints: {
+    configurable: true,
+    configurationRequired: false
+  }
+};
+
+module.exports = (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  // Parse config from URL path (passed as query param by vercel rewrite)
+  const config = decodeConfig(req.query.config);
+
+  // Create a personalized manifest name if config has settings
+  const manifestCopy = { ...manifest };
+  if (config.quality && config.quality !== 'any') {
+    manifestCopy.name = `Flix-Finder (${config.quality})`;
+  }
+
+  res.status(200).json(manifestCopy);
+};

--- a/api/config-stream.js
+++ b/api/config-stream.js
@@ -1,0 +1,35 @@
+const { fetchExtResults, normalizeImdbId, parseConfig, filterStreams } = require('../lib/ext');
+const { resolveDebridStreams } = require('../lib/debrid');
+
+function decodeConfig(configStr) {
+  if (!configStr) return {};
+  try {
+    const decoded = Buffer.from(configStr, 'base64').toString('utf8');
+    return JSON.parse(decoded);
+  } catch {
+    return {};
+  }
+}
+
+module.exports = async (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Content-Type', 'application/json');
+
+  const { type, id } = req.query;
+
+  if (!normalizeImdbId(id)) {
+    return res.status(200).json({ streams: [] });
+  }
+
+  try {
+    // Decode config from URL path (passed as query param by vercel rewrite)
+    const decodedConfig = decodeConfig(req.query.config);
+    const config = parseConfig(decodedConfig);
+    const streams = await fetchExtResults(id, { type });
+    const filtered = filterStreams(streams, config);
+    const resolved = await resolveDebridStreams(filtered, config);
+    res.status(200).json({ streams: resolved });
+  } catch (err) {
+    res.status(200).json({ streams: [] });
+  }
+};

--- a/public/configure.html
+++ b/public/configure.html
@@ -182,8 +182,13 @@
       const $ = id => document.getElementById(id);
       const fields = ['quality', 'maxResults', 'include', 'exclude', 'debrid', 'debridToken'];
 
+      function encodeConfig(config) {
+        const json = JSON.stringify(config);
+        return btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      }
+
       function update() {
-        const p = new URLSearchParams();
+        const config = {};
         const q = $('quality').value;
         const m = $('maxResults').value;
         const i = $('include').value.trim();
@@ -191,15 +196,20 @@
         const d = $('debrid').value;
         const t = $('debridToken').value.trim();
 
-        if (q && q !== 'any') p.set('quality', q);
-        if (m && m !== '10') p.set('maxResults', m);
-        if (i) p.set('include', i);
-        if (e) p.set('exclude', e);
-        if (d && d !== 'none') p.set('debrid', d);
-        if (t) p.set('debridToken', t);
+        if (q && q !== 'any') config.quality = q;
+        if (m && m !== '10') config.maxResults = parseInt(m, 10);
+        if (i) config.include = i;
+        if (e) config.exclude = e;
+        if (d && d !== 'none') config.debrid = d;
+        if (t) config.debridToken = t;
 
-        const base = location.origin + '/manifest.json';
-        const url = p.toString() ? base + '?' + p : base;
+        let url;
+        if (Object.keys(config).length > 0) {
+          const encoded = encodeConfig(config);
+          url = location.origin + '/' + encoded + '/manifest.json';
+        } else {
+          url = location.origin + '/manifest.json';
+        }
 
         $('url').textContent = url;
         $('install').href = 'stremio://' + url.replace(/^https?:\/\//, '');

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
   "rewrites": [
+    { "source": "/:config/manifest.json", "destination": "/api/config-manifest?config=:config" },
+    { "source": "/:config/stream/:type/:id.json", "destination": "/api/config-stream?config=:config&type=:type&id=:id" },
     { "source": "/manifest.json", "destination": "/api/manifest" },
     { "source": "/stream/:type/:id.json", "destination": "/api/stream/:type/:id" },
     { "source": "/configure", "destination": "/configure.html" }


### PR DESCRIPTION
The Stremio addon protocol requires configuration to be in the URL path,
not as query parameters. Changed URL format from:
  /manifest.json?quality=2160p
to:
  /{base64-config}/manifest.json

- Add new vercel.json routes for /:config/manifest.json and /:config/stream/:type/:id.json
- Create api/config-manifest.js to handle config-based manifest requests
- Create api/config-stream.js to handle config-based stream requests
- Update configure.html to generate base64-encoded config URLs

https://claude.ai/code/session_01FxYirmevAvDJobXQ7e6M3c