### PR TITLE
Add multi-source torrent search: 1337x and TorrentGalaxy scrapers

### DIFF
--- a/api/config-stream.js
+++ b/api/config-stream.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
     // Decode config from URL path (passed as query param by vercel rewrite)
     const decodedConfig = decodeConfig(req.query.config);
     const config = parseConfig(decodedConfig);
-    const streams = await fetchExtResults(id, { type });
+    const streams = await fetchExtResults(id, { type, providers: config.providers });
     const filtered = filterStreams(streams, config);
     const resolved = await resolveDebridStreams(filtered, config);
     res.status(200).json({ streams: resolved });

--- a/api/stream/[type]/[id].js
+++ b/api/stream/[type]/[id].js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
 
   try {
     const config = parseConfig(req.query);
-    const streams = await fetchExtResults(id, { type });
+    const streams = await fetchExtResults(id, { type, providers: config.providers });
     const filtered = filterStreams(streams, config);
     const resolved = await resolveDebridStreams(filtered, config);
     res.status(200).json({ streams: resolved });

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -1,3 +1,5 @@
+const { search1337x, searchTorrentGalaxy } = require('./scrapers');
+
 const KNABEN_API = 'https://api.knaben.org/v1';
 const CINEMETA_API = 'https://v3-cinemeta.strem.io/meta';
 
@@ -14,13 +16,21 @@ async function fetchMeta(imdbId, type) {
 
 function parseConfig(query) {
   query = query || {};
+  const defaultProviders = ['knaben', '1337x', 'torrentgalaxy'];
+  let providers = defaultProviders;
+
+  if (query.providers) {
+    providers = String(query.providers).split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+  }
+
   return {
     quality: String(query.quality || 'any'),
     debridService: String(query.debrid || 'none').toLowerCase(),
     debridToken: String(query.debridToken || '').trim(),
     include: String(query.include || '').split(',').map(s => s.trim()).filter(Boolean),
     exclude: String(query.exclude || '').split(',').map(s => s.trim()).filter(Boolean),
-    maxResults: Math.max(parseInt(query.maxResults, 10) || 10, 0)
+    maxResults: Math.max(parseInt(query.maxResults, 10) || 10, 0),
+    providers
   };
 }
 
@@ -74,8 +84,65 @@ function filterStreams(streams, config) {
   return config.maxResults ? result.slice(0, config.maxResults) : result;
 }
 
+async function searchKnaben(query) {
+  try {
+    const res = await fetch(KNABEN_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        search_field: 'title',
+        query,
+        order_by: 'seeders',
+        order_direction: 'desc',
+        from: 0,
+        size: 15,
+        hide_unsafe: true,
+        hide_xxx: true
+      })
+    });
+
+    if (!res.ok) return [];
+    const data = await res.json();
+
+    const streams = [];
+    const seen = new Set();
+
+    for (const hit of (data.hits || [])) {
+      let infoHash = hit.hash;
+      const magnet = [hit.magnetUrl, hit.magnetLink]
+        .find(value => typeof value === 'string' && value.startsWith('magnet:'));
+
+      if (!infoHash && magnet) {
+        const match = magnet.match(/urn:btih:([a-fA-F0-9]{40})/i);
+        if (match) infoHash = match[1].toLowerCase();
+      }
+
+      if (!infoHash || seen.has(infoHash)) continue;
+      seen.add(infoHash);
+
+      const size = formatBytes(hit.bytes);
+      const seeds = hit.seeders || 0;
+      const src = hit.cachedOrigin || 'Knaben';
+      const displayTitle = hit.title || 'Unknown';
+
+      streams.push({
+        name: 'Flix-Finder',
+        title: `${displayTitle}\n${size} | S:${seeds} | ${src}`,
+        infoHash,
+        seeders: seeds,
+        source: 'knaben'
+      });
+    }
+
+    return streams;
+  } catch (e) {
+    return [];
+  }
+}
+
 async function searchTorrents(id, options) {
   const type = options?.type || 'movie';
+  const providers = options?.providers || ['knaben', '1337x', 'torrentgalaxy'];
   const parsed = parseId(id);
   if (!parsed) return [];
 
@@ -91,59 +158,35 @@ async function searchTorrents(id, options) {
     query = `${meta.name} S${s}E${e}`;
   }
 
-  try {
-    const res = await fetch(KNABEN_API, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        search_field: 'title',
-        query,
-        order_by: 'seeders',
-        order_direction: 'desc',
-        from: 0,
-        size: 10,
-        hide_unsafe: true,
-        hide_xxx: true
-      })
-    });
+  const allStreams = [];
+  const searches = [];
 
-    if (!res.ok) return [];
-    const data = await res.json();
-
-    const streams = [];
-    const seen = new Set();
-
-    for (const hit of (data.hits || [])) {
-      // Try to get infohash from the hit directly, or extract from magnet link
-      let infoHash = hit.hash;
-      const magnet = [hit.magnetUrl, hit.magnetLink]
-        .find(value => typeof value === 'string' && value.startsWith('magnet:'));
-
-      // Extract infoHash from magnet link if not available directly
-      if (!infoHash && magnet) {
-        const match = magnet.match(/urn:btih:([a-fA-F0-9]{40})/i);
-        if (match) infoHash = match[1].toLowerCase();
-      }
-
-      if (!infoHash || seen.has(infoHash)) continue;
-      seen.add(infoHash);
-
-      const size = formatBytes(hit.bytes);
-      const seeds = hit.seeders || 0;
-      const src = hit.cachedOrigin || 'Unknown';
-      const displayTitle = hit.title || meta.name || 'Unknown';
-
-      streams.push({
-        name: 'Flix-Finder',
-        title: `${displayTitle}\n${size} | S:${seeds} | ${src}`,
-        infoHash: infoHash
-      });
-    }
-
-    return streams;
-  } catch (e) {
-    return [];
+  if (providers.includes('knaben')) {
+    searches.push(searchKnaben(query).then(r => allStreams.push(...r)).catch(() => {}));
   }
+  if (providers.includes('1337x')) {
+    searches.push(search1337x(query).then(r => allStreams.push(...r)).catch(() => {}));
+  }
+  if (providers.includes('torrentgalaxy')) {
+    searches.push(searchTorrentGalaxy(query).then(r => allStreams.push(...r)).catch(() => {}));
+  }
+
+  await Promise.allSettled(searches);
+
+  // Deduplicate by infoHash
+  const seen = new Set();
+  const uniqueStreams = [];
+  for (const stream of allStreams) {
+    if (!seen.has(stream.infoHash)) {
+      seen.add(stream.infoHash);
+      uniqueStreams.push(stream);
+    }
+  }
+
+  // Sort by seeders
+  uniqueStreams.sort((a, b) => (b.seeders || 0) - (a.seeders || 0));
+
+  return uniqueStreams;
 }
 
 module.exports = {

--- a/lib/scrapers.js
+++ b/lib/scrapers.js
@@ -1,0 +1,173 @@
+const cheerio = require('cheerio');
+
+const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+const defaultHeaders = {
+  'User-Agent': USER_AGENT,
+  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+  'Accept-Language': 'en-US,en;q=0.5',
+  'Accept-Encoding': 'gzip, deflate, br',
+  'DNT': '1',
+  'Connection': 'keep-alive',
+  'Upgrade-Insecure-Requests': '1'
+};
+
+function extractInfoHash(magnet) {
+  if (!magnet) return null;
+  const match = magnet.match(/urn:btih:([a-fA-F0-9]{40})/i);
+  if (match) return match[1].toLowerCase();
+  // Handle base32 encoded info hash
+  const base32Match = magnet.match(/urn:btih:([a-zA-Z2-7]{32})/i);
+  if (base32Match) return base32Match[1].toLowerCase();
+  return null;
+}
+
+function formatBytes(sizeStr) {
+  // Already formatted, just return it
+  return sizeStr || '';
+}
+
+// 1337x Scraper
+async function search1337x(query) {
+  const baseUrl = 'https://1337x.to';
+  const searchUrl = `${baseUrl}/search/${encodeURIComponent(query)}/1/`;
+
+  try {
+    const response = await fetch(searchUrl, { headers: defaultHeaders });
+    if (!response.ok) return [];
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    const streams = [];
+    const seen = new Set();
+
+    const rows = $('.table-list tbody tr');
+
+    // Process rows (limit to avoid too many requests)
+    const rowsToProcess = rows.slice(0, 10);
+
+    for (let i = 0; i < rowsToProcess.length; i++) {
+      const tr = rowsToProcess[i];
+      try {
+        const name = $(tr).find('.coll-1.name a').last().text().trim();
+        const detailPath = $(tr).find('.coll-1.name a').last().attr('href');
+        const seeders = parseInt($(tr).find('.coll-2.seeds').text().trim(), 10) || 0;
+        const leechers = parseInt($(tr).find('.coll-3.leeches').text().trim(), 10) || 0;
+        const size = $(tr).find('.coll-4.size').text().trim().replace(/\d+$/, '').trim();
+
+        if (!detailPath || !name) continue;
+
+        // Fetch detail page for magnet link
+        const detailUrl = `${baseUrl}${detailPath}`;
+        const detailResponse = await fetch(detailUrl, { headers: defaultHeaders });
+        if (!detailResponse.ok) continue;
+
+        const detailHtml = await detailResponse.text();
+        const detail$ = cheerio.load(detailHtml);
+        const magnet = detail$('a[href^="magnet:?xt=urn:btih"]').attr('href');
+
+        const infoHash = extractInfoHash(magnet);
+        if (!infoHash || seen.has(infoHash)) continue;
+        seen.add(infoHash);
+
+        streams.push({
+          name: 'Flix-Finder',
+          title: `${name}\n${size} | S:${seeders} L:${leechers} | 1337x`,
+          infoHash,
+          seeders,
+          source: '1337x'
+        });
+      } catch (e) {
+        // Skip failed items
+        continue;
+      }
+    }
+
+    return streams;
+  } catch (e) {
+    console.error('1337x scraper error:', e.message);
+    return [];
+  }
+}
+
+// TorrentGalaxy Scraper
+async function searchTorrentGalaxy(query) {
+  const baseUrl = 'https://torrentgalaxy.to';
+  const searchUrl = `${baseUrl}/torrents.php?search=${encodeURIComponent(query)}&lang=0&nox=2`;
+
+  try {
+    const response = await fetch(searchUrl, { headers: defaultHeaders });
+    if (!response.ok) return [];
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    const streams = [];
+    const seen = new Set();
+
+    const rows = $('.tgxtablerow');
+
+    rows.each((i, row) => {
+      if (i >= 15) return false; // Limit results
+
+      try {
+        const name = $(row).find('a[href^="/torrent/"]').attr('title') ||
+                     $(row).find('a[href^="/torrent/"]').text().trim();
+        const magnet = $(row).find('a[href^="magnet:"]').attr('href');
+        const sizeEl = $(row).find('span.badge-secondary').first();
+        const size = sizeEl.text().trim();
+
+        // Find seeders/leechers
+        const slCell = $(row).find('span[title="Seeders/Leechers"]').parent();
+        const seedText = $(row).find('span[style*="color:green"], font[color="green"]').first().text().trim();
+        const leechText = $(row).find('span[style*="color:#ff0000"], font[color="#ff0000"]').first().text().trim();
+        const seeders = parseInt(seedText, 10) || 0;
+        const leechers = parseInt(leechText, 10) || 0;
+
+        const infoHash = extractInfoHash(magnet);
+        if (!infoHash || seen.has(infoHash) || !name) return;
+        seen.add(infoHash);
+
+        streams.push({
+          name: 'Flix-Finder',
+          title: `${name}\n${size} | S:${seeders} L:${leechers} | TGx`,
+          infoHash,
+          seeders,
+          source: 'torrentgalaxy'
+        });
+      } catch (e) {
+        // Skip failed items
+      }
+    });
+
+    return streams;
+  } catch (e) {
+    console.error('TorrentGalaxy scraper error:', e.message);
+    return [];
+  }
+}
+
+// Export all scrapers
+module.exports = {
+  search1337x,
+  searchTorrentGalaxy,
+
+  // Combined search function
+  async searchAll(query, providers = ['knaben', '1337x', 'torrentgalaxy']) {
+    const results = [];
+    const searches = [];
+
+    if (providers.includes('1337x')) {
+      searches.push(search1337x(query).then(r => results.push(...r)));
+    }
+    if (providers.includes('torrentgalaxy')) {
+      searches.push(searchTorrentGalaxy(query).then(r => results.push(...r)));
+    }
+
+    await Promise.allSettled(searches);
+
+    // Sort by seeders
+    results.sort((a, b) => (b.seeders || 0) - (a.seeders || 0));
+
+    return results;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "2.0.0",
   "private": true,
   "main": "api/manifest.js",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "cheerio": "^1.0.0"
+  }
 }

--- a/public/configure.html
+++ b/public/configure.html
@@ -85,6 +85,29 @@
         color: #666;
         margin-top: 4px;
       }
+      .checkbox-group {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 8px;
+      }
+      .checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        cursor: pointer;
+      }
+      .checkbox-item input[type="checkbox"] {
+        width: 18px;
+        height: 18px;
+        cursor: pointer;
+        accent-color: #667eea;
+      }
+      .checkbox-item label {
+        margin: 0;
+        cursor: pointer;
+        font-size: 13px;
+      }
       .cta {
         display: flex;
         gap: 12px;
@@ -159,6 +182,23 @@
       <input id="exclude" type="text" placeholder="CAM, TS, HDCAM" />
       <p class="hint">Comma separated. Any match is excluded.</p>
 
+      <label>Torrent Providers</label>
+      <div class="checkbox-group">
+        <div class="checkbox-item">
+          <input type="checkbox" id="prov_knaben" value="knaben" checked />
+          <label for="prov_knaben">Knaben</label>
+        </div>
+        <div class="checkbox-item">
+          <input type="checkbox" id="prov_1337x" value="1337x" checked />
+          <label for="prov_1337x">1337x</label>
+        </div>
+        <div class="checkbox-item">
+          <input type="checkbox" id="prov_tgx" value="torrentgalaxy" checked />
+          <label for="prov_tgx">TorrentGalaxy</label>
+        </div>
+      </div>
+      <p class="hint">Select torrent sources to search</p>
+
       <label for="debrid">Debrid Service</label>
       <select id="debrid">
         <option value="none">None (magnet links)</option>
@@ -181,10 +221,18 @@
     <script>
       const $ = id => document.getElementById(id);
       const fields = ['quality', 'maxResults', 'include', 'exclude', 'debrid', 'debridToken'];
+      const providerIds = ['prov_knaben', 'prov_1337x', 'prov_tgx'];
+      const defaultProviders = ['knaben', '1337x', 'torrentgalaxy'];
 
       function encodeConfig(config) {
         const json = JSON.stringify(config);
         return btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      }
+
+      function getSelectedProviders() {
+        return providerIds
+          .filter(id => $(id).checked)
+          .map(id => $(id).value);
       }
 
       function update() {
@@ -195,6 +243,7 @@
         const e = $('exclude').value.trim();
         const d = $('debrid').value;
         const t = $('debridToken').value.trim();
+        const providers = getSelectedProviders();
 
         if (q && q !== 'any') config.quality = q;
         if (m && m !== '10') config.maxResults = parseInt(m, 10);
@@ -202,6 +251,13 @@
         if (e) config.exclude = e;
         if (d && d !== 'none') config.debrid = d;
         if (t) config.debridToken = t;
+
+        // Only add providers if not all are selected (to keep URL shorter)
+        if (providers.length > 0 && providers.length < defaultProviders.length) {
+          config.providers = providers.join(',');
+        } else if (providers.length === 0) {
+          config.providers = 'knaben'; // Default to at least one
+        }
 
         let url;
         if (Object.keys(config).length > 0) {
@@ -217,6 +273,10 @@
 
       fields.forEach(id => {
         $(id).addEventListener('input', update);
+        $(id).addEventListener('change', update);
+      });
+
+      providerIds.forEach(id => {
         $(id).addEventListener('change', update);
       });
 


### PR DESCRIPTION
- Add cheerio dependency for HTML parsing
- Create lib/scrapers.js with 1337x and TorrentGalaxy scrapers
- Update lib/ext.js to support multiple providers (knaben, 1337x, torrentgalaxy)
- Add provider selection checkboxes to configure.html
- Update API handlers to pass provider config

Users can now select which torrent sources to search from. All sources are enabled by default.

https://claude.ai/code/session_01FxYirmevAvDJobXQ7e6M3c