### PR TITLE
Add Discord invite section to configuration page

### DIFF
--- a/public/configure.html
+++ b/public/configure.html
@@ -119,6 +119,47 @@
         word-break: break-all;
         color: #888;
       }
+      .community {
+        margin-top: 24px;
+        padding: 16px;
+        border-radius: 12px;
+        background: linear-gradient(135deg, rgba(88, 101, 242, 0.18), rgba(114, 137, 218, 0.08));
+        border: 1px solid rgba(114, 137, 218, 0.35);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+      }
+      .community-text {
+        font-size: 14px;
+        color: #d9dcff;
+      }
+      .community-text strong {
+        display: block;
+        font-size: 16px;
+        margin-bottom: 4px;
+        color: #fff;
+      }
+      .discord-link {
+        padding: 10px 16px;
+        border-radius: 999px;
+        background: #5865f2;
+        color: #fff;
+        font-weight: 600;
+        font-size: 13px;
+        text-decoration: none;
+        box-shadow: 0 8px 18px rgba(88, 101, 242, 0.35);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        white-space: nowrap;
+      }
+      .discord-link:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 24px rgba(88, 101, 242, 0.45);
+      }
+      .discord-link:focus-visible {
+        outline: 3px solid rgba(143, 164, 255, 0.8);
+        outline-offset: 2px;
+      }
       @media (max-width: 500px) {
         .row { grid-template-columns: 1fr; }
         .cta { flex-direction: column; }
@@ -176,6 +217,21 @@
       </div>
 
       <div class="url-box" id="url"></div>
+
+      <div class="community">
+        <div class="community-text">
+          <strong>Csatlakozz a Discord közösséghez</strong>
+          Kapj frissítéseket, tippeket és segítséget más Flix-Finder felhasználóktól.
+        </div>
+        <a
+          class="discord-link"
+          href="https://discord.gg/GnKRAwwdcQ"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Discord meghívó
+        </a>
+      </div>
     </div>
 
     <script>


### PR DESCRIPTION
### Motivation
- Make it easy for users to join the project community by adding a prominent, well-styled Discord invite to the config UI.

### Description
- Add a new `.community` callout block to `public/configure.html` containing Hungarian copy and a Discord invite button linking to `https://discord.gg/GnKRAwwdcQ`.
- Add CSS rules for the callout, text, and a rounded Discord button with hover and focus-visible states for accessibility and visual polish.
- Place the callout below the generated URL box so it’s visible during configuration.

### Testing
- Started a static server using `python -m http.server 8000 --directory public` and confirmed the page served successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/configure.html` and captured a full-page screenshot (`artifacts/discord-link.png`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698100f636fc83318e44ef4ffa531626)