### PR TITLE
Redirect home route to /configure

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+  "redirects": [
+    { "source": "/", "destination": "/configure", "permanent": false }
+  ],
   "rewrites": [
     { "source": "/:config/manifest.json", "destination": "/api/config-manifest?config=:config" },
     { "source": "/:config/stream/:type/:id.json", "destination": "/api/config-stream?config=:config&type=:type&id=:id" },


### PR DESCRIPTION
### Motivation
- Ensure the site root (`/`) displays the same configure UI by redirecting it to the existing `/configure` endpoint.

### Description
- Add a `redirects` entry to `vercel.json` that maps `"/"` to `"/configure"` with `permanent: false`, while leaving the existing `rewrites` intact.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981918b3e9c83318f7df6892085ff9a)