### PR TITLE
Add EZTV fallback for series torrents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Stremio addon for torrent streaming. Searches multiple torrent indexers and retu
 ## Features
 
 - Torrent search via Knaben aggregator (TPB, 1337x, RARBG, RuTracker, etc.)
+- TV torrent fallback via EZTV API
 - Movies and TV series support
 - Quality filtering (4K, 1080p, 720p)
 - Keyword filters (include/exclude)

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -1,4 +1,5 @@
 const KNABEN_API = 'https://api.knaben.org/v1';
+const EZTV_API = 'https://eztvx.to/api';
 const CINEMETA_API = 'https://v3-cinemeta.strem.io/meta';
 
 async function fetchMeta(imdbId, type) {
@@ -74,23 +75,7 @@ function filterStreams(streams, config) {
   return config.maxResults ? result.slice(0, config.maxResults) : result;
 }
 
-async function searchTorrents(id, options) {
-  const type = options?.type || 'movie';
-  const parsed = parseId(id);
-  if (!parsed) return [];
-
-  const meta = await fetchMeta(parsed.imdbId, type);
-  if (!meta?.name) return [];
-
-  let query = meta.name;
-  if (type === 'movie' && meta.year) {
-    query = `${meta.name} ${meta.year}`;
-  } else if (type === 'series' && parsed.season != null && parsed.episode != null) {
-    const s = String(parsed.season).padStart(2, '0');
-    const e = String(parsed.episode).padStart(2, '0');
-    query = `${meta.name} S${s}E${e}`;
-  }
-
+async function searchKnaben(query) {
   try {
     const res = await fetch(KNABEN_API, {
       method: 'POST',
@@ -142,6 +127,96 @@ async function searchTorrents(id, options) {
   } catch (e) {
     return [];
   }
+}
+
+async function searchEztv(id, options) {
+  const parsed = parseId(id);
+  if (!parsed?.imdbId) return [];
+  const imdbNumeric = parsed.imdbId.replace(/^tt/i, '');
+  if (!/^\d+$/.test(imdbNumeric)) return [];
+
+  const url = new URL(`${EZTV_API}/get-torrents`);
+  url.searchParams.set('imdb_id', imdbNumeric);
+  url.searchParams.set('limit', '20');
+  url.searchParams.set('page', '1');
+
+  if (options?.type === 'series' && parsed.season != null && parsed.episode != null) {
+    url.searchParams.set('season', String(parsed.season));
+    url.searchParams.set('episode', String(parsed.episode));
+  }
+
+  try {
+    const res = await fetch(url.toString(), {
+      headers: { 'User-Agent': 'Flix-Finder/2.0' }
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+
+    const streams = [];
+    const seen = new Set();
+
+    for (const item of (data.torrents || [])) {
+      let infoHash = item.hash || item.info_hash;
+      const magnet = item.magnet_url || item.magnetUrl || item.magnet;
+
+      if (!infoHash && magnet) {
+        const match = String(magnet).match(/urn:btih:([a-fA-F0-9]{40})/i);
+        if (match) infoHash = match[1].toLowerCase();
+      }
+
+      if (!infoHash || seen.has(infoHash)) continue;
+      seen.add(infoHash);
+
+      const size = formatBytes(item.size_bytes || item.size);
+      const seeds = item.seeds || item.seeders || 0;
+      const displayTitle = item.title || item.filename || 'Unknown';
+
+      streams.push({
+        name: 'Flix-Finder',
+        title: `${displayTitle}\n${size} | S:${seeds} | EZTV`,
+        infoHash
+      });
+    }
+
+    return streams;
+  } catch (e) {
+    return [];
+  }
+}
+
+function uniqueByInfoHash(streams) {
+  const seen = new Set();
+  return streams.filter(stream => {
+    if (!stream.infoHash) return false;
+    if (seen.has(stream.infoHash)) return false;
+    seen.add(stream.infoHash);
+    return true;
+  });
+}
+
+async function searchTorrents(id, options) {
+  const type = options?.type || 'movie';
+  const parsed = parseId(id);
+  if (!parsed) return [];
+
+  const meta = await fetchMeta(parsed.imdbId, type);
+  if (!meta?.name) return [];
+
+  let query = meta.name;
+  if (type === 'movie' && meta.year) {
+    query = `${meta.name} ${meta.year}`;
+  } else if (type === 'series' && parsed.season != null && parsed.episode != null) {
+    const s = String(parsed.season).padStart(2, '0');
+    const e = String(parsed.episode).padStart(2, '0');
+    query = `${meta.name} S${s}E${e}`;
+  }
+
+  const [knabenResults, eztvResults] = await Promise.all([
+    searchKnaben(query),
+    type === 'series' ? searchEztv(id, { type }) : []
+  ]);
+
+  return uniqueByInfoHash([...knabenResults, ...eztvResults]);
 }
 
 module.exports = {


### PR DESCRIPTION
### Motivation

- Improve series torrent coverage by querying an additional TV-focused index when Knaben doesn't return episode-specific results.
- Reduce duplicate streams when merging results from multiple providers.

### Description

- Add `EZTV_API` constant and a new `searchEztv` function to fetch series torrents from the EZTV API using the parsed IMDB id.
- Refactor the Knaben search into `searchKnaben(query)` and keep existing parsing/formatting behavior.
- Merge Knaben and EZTV results in `searchTorrents` for series queries and deduplicate entries using `uniqueByInfoHash`. 
- Export unchanged public API while wiring `fetchExtResults` to the updated `searchTorrents` implementation. 
- Document the EZTV fallback in the `README.md` feature list.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819c28b64c83318b731409a15e2f39)