### PR TITLE
Add source selection to configuration

### DIFF
--- a/api/config-stream.js
+++ b/api/config-stream.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
     // Decode config from URL path (passed as query param by vercel rewrite)
     const decodedConfig = decodeConfig(req.query.config);
     const config = parseConfig(decodedConfig);
-    const streams = await fetchExtResults(id, { type });
+    const streams = await fetchExtResults(id, { type, sources: config.sources });
     const filtered = filterStreams(streams, config);
     const resolved = await resolveDebridStreams(filtered, config);
     res.status(200).json({ streams: resolved });

--- a/api/stream/[type]/[id].js
+++ b/api/stream/[type]/[id].js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
 
   try {
     const config = parseConfig(req.query);
-    const streams = await fetchExtResults(id, { type });
+    const streams = await fetchExtResults(id, { type, sources: config.sources });
     const filtered = filterStreams(streams, config);
     const resolved = await resolveDebridStreams(filtered, config);
     res.status(200).json({ streams: resolved });

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -2,6 +2,7 @@ const KNABEN_API = 'https://api.knaben.org/v1';
 const EZTV_API = 'https://eztvx.to/api';
 const YTS_API = 'https://yts.bz/api/v2';
 const CINEMETA_API = 'https://v3-cinemeta.strem.io/meta';
+const ALL_SOURCES = ['knaben', 'eztv', 'yts'];
 
 async function fetchMeta(imdbId, type) {
   const res = await fetch(`${CINEMETA_API}/${type}/${imdbId}.json`);
@@ -16,13 +17,19 @@ async function fetchMeta(imdbId, type) {
 
 function parseConfig(query) {
   query = query || {};
+  const rawSources = query.sources;
+  const normalizedSources = Array.isArray(rawSources)
+    ? rawSources.map(source => String(source).toLowerCase().trim()).filter(Boolean)
+    : String(rawSources || '').split(',').map(source => source.trim().toLowerCase()).filter(Boolean);
+  const sources = rawSources == null ? ALL_SOURCES : normalizedSources.filter(source => ALL_SOURCES.includes(source));
   return {
     quality: String(query.quality || 'any'),
     debridService: String(query.debrid || 'none').toLowerCase(),
     debridToken: String(query.debridToken || '').trim(),
     include: String(query.include || '').split(',').map(s => s.trim()).filter(Boolean),
     exclude: String(query.exclude || '').split(',').map(s => s.trim()).filter(Boolean),
-    maxResults: Math.max(parseInt(query.maxResults, 10) || 10, 0)
+    maxResults: Math.max(parseInt(query.maxResults, 10) || 10, 0),
+    sources
   };
 }
 
@@ -259,6 +266,7 @@ function mergeRoundRobin(groups) {
 
 async function searchTorrents(id, options) {
   const type = options?.type || 'movie';
+  const sources = options?.sources || ALL_SOURCES;
   const parsed = parseId(id);
   if (!parsed) return [];
 
@@ -277,9 +285,9 @@ async function searchTorrents(id, options) {
   }
 
   const [knabenResults, eztvResults, ytsResults] = await Promise.all([
-    query ? searchKnaben(query) : [],
-    type === 'series' ? searchEztv(id, { type }) : [],
-    type === 'movie' ? searchYts(id) : []
+    query && sources.includes('knaben') ? searchKnaben(query) : [],
+    type === 'series' && sources.includes('eztv') ? searchEztv(id, { type }) : [],
+    type === 'movie' && sources.includes('yts') ? searchYts(id) : []
   ]);
 
   const merged = type === 'movie'

--- a/public/configure.html
+++ b/public/configure.html
@@ -80,6 +80,28 @@
         grid-template-columns: 1fr 1fr;
         gap: 16px;
       }
+      .source-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 12px;
+        margin-top: 8px;
+      }
+      .checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        border-radius: 10px;
+        background: #12151c;
+        border: 1px solid #2a2f3a;
+        font-size: 13px;
+        color: #d7d7d7;
+      }
+      .checkbox-item input {
+        width: 16px;
+        height: 16px;
+        accent-color: #667eea;
+      }
       .hint {
         font-size: 12px;
         color: #666;
@@ -207,6 +229,22 @@
         <option value="torbox">Torbox</option>
       </select>
 
+      <label>Sources</label>
+      <div class="source-grid" id="sourceGrid">
+        <label class="checkbox-item">
+          <input type="checkbox" name="sources" value="knaben" checked />
+          Knaben
+        </label>
+        <label class="checkbox-item">
+          <input type="checkbox" name="sources" value="eztv" checked />
+          EZTV
+        </label>
+        <label class="checkbox-item">
+          <input type="checkbox" name="sources" value="yts" checked />
+          YTS
+        </label>
+      </div>
+
       <label for="debridToken">API Token</label>
       <input id="debridToken" type="password" placeholder="Your debrid API token" />
       <p class="hint">Get from Real-Debrid or Torbox account settings</p>
@@ -237,6 +275,8 @@
     <script>
       const $ = id => document.getElementById(id);
       const fields = ['quality', 'maxResults', 'include', 'exclude', 'debrid', 'debridToken'];
+      const sourceInputs = Array.from(document.querySelectorAll('input[name="sources"]'));
+      const allSources = sourceInputs.map(input => input.value);
 
       function encodeConfig(config) {
         const json = JSON.stringify(config);
@@ -251,6 +291,7 @@
         const e = $('exclude').value.trim();
         const d = $('debrid').value;
         const t = $('debridToken').value.trim();
+        const sources = sourceInputs.filter(input => input.checked).map(input => input.value);
 
         if (q && q !== 'any') config.quality = q;
         if (m && m !== '10') config.maxResults = parseInt(m, 10);
@@ -258,6 +299,7 @@
         if (e) config.exclude = e;
         if (d && d !== 'none') config.debrid = d;
         if (t) config.debridToken = t;
+        if (sources.length !== allSources.length) config.sources = sources;
 
         let url;
         if (Object.keys(config).length > 0) {
@@ -274,6 +316,9 @@
       fields.forEach(id => {
         $(id).addEventListener('input', update);
         $(id).addEventListener('change', update);
+      });
+      sourceInputs.forEach(input => {
+        input.addEventListener('change', update);
       });
 
       $('copy').onclick = async () => {


### PR DESCRIPTION
### Motivation
- Provide users control over which torrent sources (Knaben, EZTV, YTS) the addon queries, and encode that preference into the generated config URL so endpoints can respect it.

### Description
- Add a Sources selector UI to `public/configure.html` with three checkboxes (Knaben, EZTV, YTS) that are checked by default and included in the encoded config only when not all are selected.
- Update front-end logic to collect selected sources and append them to the encoded configuration URL when appropriate (`public/configure.html`).
- Add `ALL_SOURCES` and parse/normalize `sources` in `lib/ext.js`, defaulting to all providers when none specified, and propagate `options.sources` into the torrent search calls to skip providers that are not selected.
- Pass `config.sources` from both stream endpoints (`api/stream/[type]/[id].js` and `api/config-stream.js`) into `fetchExtResults` so server-side searches honor the chosen sources.

### Testing
- Started a local HTTP server and ran a Playwright script to load `/public/configure.html` and capture a screenshot of the updated configure page, which completed successfully and produced an artifact. 
- Verified the project files were staged and committed successfully; no automated unit tests or CI runs were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981b60ccdfc83319e36e3dfadb2ab89)