### PR TITLE
Prepend debrid status badges to resolved stream titles

### DIFF
--- a/lib/debrid.js
+++ b/lib/debrid.js
@@ -99,9 +99,14 @@ async function resolveDebridStreams(streams, config) {
       if (!magnet) continue;
 
       const resolved = await resolver(magnet, config.debridToken);
+      const badge = resolved.name === 'RD'
+        ? '🟣 [RD:on]'
+        : resolved.name === 'TB'
+          ? '🔵 [TB:on]'
+          : `[${resolved.name}]`;
       results.push({
         name: resolved.name,
-        title: `[${resolved.name}] ${resolved.title}`,
+        title: `${badge} ${resolved.title}`,
         url: resolved.url
       });
     } catch (e) {


### PR DESCRIPTION
### Motivation
- When streams are resolved via a debrid service, surface a clear, modern status badge in the release title to indicate which debrid provider produced the link (Real-Debrid or Torbox) so clients can display `[RD:on]` or `[TB:on]` with color cues.

### Description
- Update `lib/debrid.js` in `resolveDebridStreams` to compute a `badge` for `resolved.name === 'RD'` (purple `🟣 [RD:on]`), `resolved.name === 'TB'` (blue `🔵 [TB:on]`), or fall back to `[<name>]`, and prepend that badge to the returned `title` for resolved streams.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d88677e083319747ffd67ab204f0)