### PR TITLE
Add AnimeTosho JSON feed source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Stremio addon for torrent streaming. Searches multiple torrent indexers and retu
 - Torrent search via Knaben aggregator (TPB, 1337x, RARBG, RuTracker, etc.)
 - TV torrents via EZTV API
 - Movie torrents via YTS API
+- Anime torrents via AnimeTosho RSS
 - Movies and TV series support
 - Quality filtering (4K, 1080p, 720p)
 - Keyword filters (include/exclude)

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -1,8 +1,9 @@
 const KNABEN_API = 'https://api.knaben.org/v1';
 const EZTV_API = 'https://eztvx.to/api';
 const YTS_API = 'https://yts.bz/api/v2';
+const ANIMETOSHO_JSON = 'https://feed.animetosho.org/json';
 const CINEMETA_API = 'https://v3-cinemeta.strem.io/meta';
-const ALL_SOURCES = ['knaben', 'eztv', 'yts'];
+const ALL_SOURCES = ['knaben', 'eztv', 'yts', 'animetosho'];
 
 async function fetchMeta(imdbId, type) {
   const res = await fetch(`${CINEMETA_API}/${type}/${imdbId}.json`);
@@ -56,6 +57,32 @@ function formatBytes(bytes) {
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return (bytes / Math.pow(k, i)).toFixed(1) + ' ' + sizes[i];
+}
+
+function extractInfoHash(value) {
+  if (!value) return null;
+  const match = String(value).match(/urn:btih:([a-fA-F0-9]{40})/i);
+  return match ? match[1].toLowerCase() : null;
+}
+
+function findMagnetLink(item) {
+  if (!item || typeof item !== 'object') return null;
+  const candidates = [];
+
+  if (typeof item.magnet === 'string') candidates.push(item.magnet);
+  if (typeof item.link === 'string') candidates.push(item.link);
+  if (typeof item.url === 'string') candidates.push(item.url);
+  if (typeof item.guid === 'string') candidates.push(item.guid);
+  if (typeof item.torrent === 'string') candidates.push(item.torrent);
+
+  if (item.enclosure?.url) candidates.push(item.enclosure.url);
+  if (Array.isArray(item.enclosures)) {
+    for (const enclosure of item.enclosures) {
+      if (enclosure?.url) candidates.push(enclosure.url);
+    }
+  }
+
+  return candidates.find(candidate => String(candidate).startsWith('magnet:')) || null;
 }
 
 function filterStreams(streams, config) {
@@ -243,6 +270,46 @@ async function searchYts(id) {
   }
 }
 
+async function searchAnimetosho(query) {
+  if (!query) return [];
+
+  try {
+    const url = new URL(ANIMETOSHO_JSON);
+    url.searchParams.set('filter', query);
+
+    const res = await fetch(url.toString(), {
+      headers: { 'User-Agent': 'Flix-Finder/2.0' }
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    const items = data?.items || data?.channel?.item || data?.channel?.items || [];
+
+    const streams = [];
+    const seen = new Set();
+
+    for (const item of items) {
+      const magnet = findMagnetLink(item);
+      const infoHash = item?.info_hash || item?.infoHash || extractInfoHash(magnet);
+      if (!infoHash || seen.has(infoHash)) continue;
+      seen.add(infoHash);
+
+      const title = item?.title || item?.name || 'Unknown';
+      const size = formatBytes(item?.size || item?.content_length || item?.enclosure?.length);
+      const seeds = item?.seeders || item?.seeds || 0;
+
+      streams.push({
+        name: 'Flix-Finder',
+        title: `${title}\n${size} | S:${seeds} | AnimeTosho`,
+        infoHash
+      });
+    }
+
+    return streams;
+  } catch (e) {
+    return [];
+  }
+}
+
 function uniqueByInfoHash(streams) {
   const seen = new Set();
   return streams.filter(stream => {
@@ -290,9 +357,13 @@ async function searchTorrents(id, options) {
     type === 'movie' && sources.includes('yts') ? searchYts(id) : []
   ]);
 
+  const animetoshoResults = sources.includes('animetosho')
+    ? await searchAnimetosho(query)
+    : [];
+
   const merged = type === 'movie'
-    ? mergeRoundRobin([knabenResults, ytsResults])
-    : mergeRoundRobin([knabenResults, eztvResults]);
+    ? mergeRoundRobin([knabenResults, ytsResults, animetoshoResults])
+    : mergeRoundRobin([knabenResults, eztvResults, animetoshoResults]);
   return uniqueByInfoHash(merged);
 }
 

--- a/public/configure.html
+++ b/public/configure.html
@@ -243,6 +243,10 @@
           <input type="checkbox" name="sources" value="yts" checked />
           YTS
         </label>
+        <label class="checkbox-item">
+          <input type="checkbox" name="sources" value="animetosho" checked />
+          AnimeTosho
+        </label>
       </div>
 
       <label for="debridToken">API Token</label>


### PR DESCRIPTION
### Motivation
- Integrate AnimeTosho as an additional torrent source using the feed's JSON API so anime torrents can be discovered with richer metadata than raw RSS parsing.
- Make AnimeTosho behave like the other providers by allowing it to be selected in the UI and merged into the existing round-robin results flow.
- Provide helper parsing utilities to robustly extract magnet/info-hash and sizes from the feed items.

### Description
- Add `ANIMETOSHO_JSON = 'https://feed.animetosho.org/json'` and include `'animetosho'` in `ALL_SOURCES` in `lib/ext.js`.
- Implement `searchAnimetosho(query)` which calls the JSON endpoint, extracts items, finds magnet links via `findMagnetLink`, and derives info-hashes with `extractInfoHash` to produce stream objects.
- Add `extractInfoHash` and `findMagnetLink` helper functions to handle multiple possible feed item shapes and enclosure formats.
- Merge AnimeTosho results into `searchTorrents` with the existing round-robin logic for both movies and series, and deduplicate by info-hash via `uniqueByInfoHash`.
- Add a selectable `animetosho` checkbox in `public/configure.html` so users can toggle the source, and update `README.md` to list AnimeTosho support.

### Testing
- No automated tests were executed for this change (no test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f44fbff083319ff38fb54c9a5c39)