### PR TITLE
Fix AnimeTosho query encoding and prefer base anime title

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -265,7 +265,10 @@ async function searchAnimetosho(query) {
 
   try {
     const url = new URL(ANIMETOSHO_SEARCH);
-    url.searchParams.set('q', query);
+    const normalizedQuery = query.trim().replace(/\s+/g, ' ');
+    const encodedQuery = encodeURIComponent(normalizedQuery).replace(/%20/g, '+');
+    if (!encodedQuery || encodedQuery === '+') return [];
+    url.search = `?q=${encodedQuery}`;
 
     const res = await fetch(url.toString(), {
       headers: { 'User-Agent': 'Flix-Finder/2.0' }
@@ -342,16 +345,17 @@ async function searchTorrents(id, options) {
   if (!parsed) return [];
 
   const meta = await fetchMeta(parsed.imdbId, type);
+  const baseTitle = meta?.name ? meta.name.trim() : null;
 
   let query = null;
-  if (meta?.name) {
-    query = meta.name;
+  if (baseTitle) {
+    query = baseTitle;
     if (type === 'movie' && meta.year) {
-      query = `${meta.name} ${meta.year}`;
+      query = `${baseTitle} ${meta.year}`;
     } else if (type === 'series' && parsed.season != null && parsed.episode != null) {
       const s = String(parsed.season).padStart(2, '0');
       const e = String(parsed.episode).padStart(2, '0');
-      query = `${meta.name} S${s}E${e}`;
+      query = `${baseTitle} S${s}E${e}`;
     }
   }
 
@@ -362,7 +366,7 @@ async function searchTorrents(id, options) {
   ]);
 
   const animetoshoResults = sources.includes('animetosho')
-    ? await searchAnimetosho(query)
+    ? await searchAnimetosho(baseTitle || query)
     : [];
 
   const merged = type === 'movie'


### PR DESCRIPTION
### Motivation
- AnimeTosho expects spaces in search queries to be represented as `+` and we should avoid sending empty or whitespace-only queries to the site. 
- The addon should prefer the plain base anime title (not just the `SxxExx` fragment) when querying AnimeTosho so the source activates correctly when it is the only enabled source.

### Description
- Update `searchAnimetosho` to normalize whitespace with `query.trim().replace(/\s+/g, ' ')`, encode with `encodeURIComponent`, convert `%20` to `+`, return early on empty queries, and set `url.search = '?q=...'`.
- Add `baseTitle = meta?.name ? meta.name.trim() : null` in `searchTorrents` and use `baseTitle` when building `query` for movies (include year) and series (include `SxxExx`).
- Call `searchAnimetosho(baseTitle || query)` so AnimeTosho receives the plain anime title when available.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821c137fe88331827d607870911a31)