### PR TITLE
Handle base32 AnimeTosho magnets and improve AnimeTosho query handling

### DIFF
--- a/lib/ext.js
+++ b/lib/ext.js
@@ -59,10 +59,32 @@ function formatBytes(bytes) {
   return (bytes / Math.pow(k, i)).toFixed(1) + ' ' + sizes[i];
 }
 
+function base32ToHex(value) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  let bits = '';
+  for (const char of value.toUpperCase()) {
+    const idx = alphabet.indexOf(char);
+    if (idx === -1) return null;
+    bits += idx.toString(2).padStart(5, '0');
+  }
+  const hex = [];
+  for (let i = 0; i + 4 <= bits.length; i += 4) {
+    const chunk = bits.slice(i, i + 4);
+    hex.push(parseInt(chunk, 2).toString(16));
+  }
+  return hex.join('');
+}
+
 function extractInfoHash(value) {
   if (!value) return null;
-  const match = String(value).match(/urn:btih:([a-fA-F0-9]{40})/i);
-  return match ? match[1].toLowerCase() : null;
+  const match = String(value).match(/urn:btih:([a-fA-F0-9]{40}|[A-Z2-7]{32})/i);
+  if (!match) return null;
+  const raw = match[1];
+  if (/^[a-fA-F0-9]{40}$/.test(raw)) {
+    return raw.toLowerCase();
+  }
+  const converted = base32ToHex(raw);
+  return converted ? converted.toLowerCase() : null;
 }
 
 function decodeHtmlEntities(value) {
@@ -265,7 +287,10 @@ async function searchAnimetosho(query) {
 
   try {
     const url = new URL(ANIMETOSHO_SEARCH);
-    url.searchParams.set('q', query);
+    const normalizedQuery = query.trim().replace(/\s+/g, ' ');
+    const encodedQuery = encodeURIComponent(normalizedQuery).replace(/%20/g, '+');
+    if (!encodedQuery || encodedQuery === '+') return [];
+    url.search = `?q=${encodedQuery}`;
 
     const res = await fetch(url.toString(), {
       headers: { 'User-Agent': 'Flix-Finder/2.0' }
@@ -276,7 +301,7 @@ async function searchAnimetosho(query) {
     const streams = [];
     const seen = new Set();
     const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
-    const magnetRegex = /(magnet:\?xt=urn:btih:[a-fA-F0-9]{40}[^"'\\s<]*)/i;
+    const magnetRegex = /(magnet:\?xt=urn:btih:(?:[a-fA-F0-9]{40}|[A-Z2-7]{32})[^"'\\s<]*)/i;
     const titleRegex = /<a[^>]+class="[^"]*name[^"]*"[^>]*>([\s\S]*?)<\/a>/i;
     const sizeRegex = /<td[^>]+class="[^"]*size[^"]*"[^>]*>([\s\S]*?)<\/td>/i;
     const seedRegex = /<td[^>]+class="[^"]*seed[^"]*"[^>]*>([\s\S]*?)<\/td>/i;
@@ -342,16 +367,17 @@ async function searchTorrents(id, options) {
   if (!parsed) return [];
 
   const meta = await fetchMeta(parsed.imdbId, type);
+  const baseTitle = meta?.name ? meta.name.trim() : null;
 
   let query = null;
-  if (meta?.name) {
-    query = meta.name;
+  if (baseTitle) {
+    query = baseTitle;
     if (type === 'movie' && meta.year) {
-      query = `${meta.name} ${meta.year}`;
+      query = `${baseTitle} ${meta.year}`;
     } else if (type === 'series' && parsed.season != null && parsed.episode != null) {
       const s = String(parsed.season).padStart(2, '0');
       const e = String(parsed.episode).padStart(2, '0');
-      query = `${meta.name} S${s}E${e}`;
+      query = `${baseTitle} S${s}E${e}`;
     }
   }
 
@@ -362,7 +388,7 @@ async function searchTorrents(id, options) {
   ]);
 
   const animetoshoResults = sources.includes('animetosho')
-    ? await searchAnimetosho(query)
+    ? await searchAnimetosho(baseTitle || query)
     : [];
 
   const merged = type === 'movie'


### PR DESCRIPTION
### Motivation
- Some AnimeTosho magnet links use base32 `btih` hashes instead of 40-char hex and were not being recognized, causing no results to be returned. 
- AnimeTosho expects spaces encoded as `+` and empty/whitespace queries should be avoided to prevent invalid searches. 
- When available, the addon should prefer the plain base anime title from metadata when building AnimeTosho queries so the source activates reliably.

### Description
- Added `base32ToHex` helper and updated `extractInfoHash` to accept base32 32-char `btih` values and convert them to hex for consistent `infoHash` IDs. 
- Expanded the magnet regex to match either 40-char hex or 32-char base32 hashes so AnimeTosho magnets are detected in HTML. 
- Normalized and encoded AnimeTosho queries by trimming and collapsing whitespace, encoding with `encodeURIComponent` and converting `%20` to `+`, and returning early for empty queries. 
- Introduced `baseTitle = meta?.name ? meta.name.trim() : null` in `searchTorrents` and used `baseTitle` when building movie/series queries, and passed `baseTitle || query` into `searchAnimetosho` so the plain anime title is preferred.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821c137fe88331827d607870911a31)