### PR TITLE
Fix base64url config decoding for debrid settings

### DIFF
--- a/api/config-manifest.js
+++ b/api/config-manifest.js
@@ -1,7 +1,9 @@
 function decodeConfig(configStr) {
   if (!configStr) return {};
   try {
-    const decoded = Buffer.from(configStr, 'base64').toString('utf8');
+    const normalized = String(configStr).replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    const decoded = Buffer.from(padded, 'base64').toString('utf8');
     return JSON.parse(decoded);
   } catch {
     return {};

--- a/api/config-stream.js
+++ b/api/config-stream.js
@@ -4,7 +4,9 @@ const { resolveDebridStreams } = require('../lib/debrid');
 function decodeConfig(configStr) {
   if (!configStr) return {};
   try {
-    const decoded = Buffer.from(configStr, 'base64').toString('utf8');
+    const normalized = String(configStr).replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    const decoded = Buffer.from(padded, 'base64').toString('utf8');
     return JSON.parse(decoded);
   } catch {
     return {};


### PR DESCRIPTION
### Motivation
- The URL-encoded addon config can be passed as base64url (URL-safe, unpadded) which previously failed to decode, causing debrid settings such as the API token to be ignored. 
- Ensuring proper decoding makes badges like `🟣 [RD:on]` and debrid playback work for configured addon links.

### Description
- Normalize base64url input and add padding before decoding in `decodeConfig` in `api/config-manifest.js` to support `-`/`_` variants and missing `=` padding. 
- Apply the same normalization and padded `Buffer.from(..., 'base64').toString('utf8')` decode in `api/config-stream.js` so config values (e.g. `debridToken`) parse correctly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982bf579b508331bbba7cf34c01339a)