### PR TITLE
Real‑Debrid: add auth_token fallback and improve link selection

### DIFF
--- a/lib/debrid.js
+++ b/lib/debrid.js
@@ -3,8 +3,21 @@ async function request(url, opts) {
     ...opts,
     headers: { 'User-Agent': 'Flix-Finder/2.0', ...(opts?.headers || {}) }
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
+  if (res.status === 204) return null;
+  const text = await res.text();
+  const data = text ? (() => {
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      return text;
+    }
+  })() : null;
+  if (!res.ok) {
+    const detail = data?.error || data?.message || data?.detail;
+    const code = data?.error_code ? ` (${data.error_code})` : '';
+    throw new Error(detail ? `${detail}${code}` : `HTTP ${res.status}`);
+  }
+  return data;
 }
 
 function sleep(ms) {
@@ -14,14 +27,19 @@ function sleep(ms) {
 async function realDebrid(magnet, token) {
   const base = 'https://api.real-debrid.com/rest/1.0';
   const auth = { Authorization: `Bearer ${token}` };
+  const withAuthToken = (path) => {
+    const url = new URL(`${base}${path}`);
+    url.searchParams.set('auth_token', token);
+    return url.toString();
+  };
 
-  const add = await request(`${base}/torrents/addMagnet`, {
+  const add = await request(withAuthToken('/torrents/addMagnet'), {
     method: 'POST',
     headers: { ...auth, 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({ magnet })
   });
 
-  await request(`${base}/torrents/selectFiles/${add.id}`, {
+  await request(withAuthToken(`/torrents/selectFiles/${add.id}`), {
     method: 'POST',
     headers: { ...auth, 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({ files: 'all' })
@@ -29,7 +47,7 @@ async function realDebrid(magnet, token) {
 
   let info;
   for (let i = 0; i < 10; i++) {
-    info = await request(`${base}/torrents/info/${add.id}`, { headers: auth });
+    info = await request(withAuthToken(`/torrents/info/${add.id}`), { headers: auth });
     if (info.status === 'downloaded' && info.links?.length) break;
     if (info.status === 'error' || info.status === 'dead') throw new Error('Torrent failed');
     await sleep(1000);
@@ -37,10 +55,21 @@ async function realDebrid(magnet, token) {
 
   if (!info?.links?.length) throw new Error('No links');
 
-  const dl = await request(`${base}/unrestrict/link`, {
+  let link = info.links[0];
+  if (Array.isArray(info.files) && info.files.length) {
+    const selectedFiles = info.files.filter(file => file.selected !== 0);
+    const files = selectedFiles.length ? selectedFiles : info.files;
+    const largest = files.reduce((max, file) => (file.bytes > max.bytes ? file : max), files[0]);
+    const selectedIndex = (selectedFiles.length ? selectedFiles : info.files).indexOf(largest);
+    if (selectedIndex >= 0 && info.links[selectedIndex]) {
+      link = info.links[selectedIndex];
+    }
+  }
+
+  const dl = await request(withAuthToken('/unrestrict/link'), {
     method: 'POST',
     headers: { ...auth, 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ link: info.links[0] })
+    body: new URLSearchParams({ link })
   });
 
   return { url: dl.download, title: info.filename || dl.filename, name: 'RD' };


### PR DESCRIPTION
### Motivation
- Real‑Debrid requests sometimes fail to activate when only an `Authorization` header is provided, so adding an `auth_token` query fallback improves reliability.
- API responses from debrid providers can be non‑JSON, empty (`204`) or contain human‑readable error details and numeric `error_code` values that should be surfaced for debugging.
- When Real‑Debrid returns multiple `info.links` entries, always using the first link may not select the intended or largest file, leading to suboptimal stream resolution.

### Description
- Updated the shared `request` helper in `lib/debrid.js` to return `null` for `204` responses, read raw response text, attempt to `JSON.parse` it, and include `error`/`message`/`detail` and `error_code` when responses are not `ok`.
- Added a `withAuthToken` helper in `realDebrid` to append `auth_token` query parameters to Real‑Debrid endpoints while keeping the `Authorization` header.
- Enhanced `realDebrid` to choose the largest selected file (or the largest file as a fallback), map that file to the corresponding `info.links` entry, and send that link to `/unrestrict/link` instead of always using `info.links[0]`.
- Kept existing Torbox flow unchanged and preserved existing retry/sleep polling logic for torrent info.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982895f701883318ceed5ae9d49e470)