### PR TITLE
Normalize base64 configs, resolve nested debrid tokens, and surface Real‑Debrid errors in streams

### DIFF
--- a/api/config-manifest.js
+++ b/api/config-manifest.js
@@ -1,7 +1,12 @@
 function decodeConfig(configStr) {
   if (!configStr) return {};
   try {
-    const decoded = Buffer.from(configStr, 'base64').toString('utf8');
+    const raw = String(configStr).replace(/ /g, '+');
+    const normalized = raw
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(raw.length / 4) * 4, '=');
+    const decoded = Buffer.from(normalized, 'base64').toString('utf8');
     return JSON.parse(decoded);
   } catch {
     return {};

--- a/api/config-stream.js
+++ b/api/config-stream.js
@@ -4,7 +4,12 @@ const { resolveDebridStreams } = require('../lib/debrid');
 function decodeConfig(configStr) {
   if (!configStr) return {};
   try {
-    const decoded = Buffer.from(configStr, 'base64').toString('utf8');
+    const raw = String(configStr).replace(/ /g, '+');
+    const normalized = raw
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(raw.length / 4) * 4, '=');
+    const decoded = Buffer.from(normalized, 'base64').toString('utf8');
     return JSON.parse(decoded);
   } catch {
     return {};

--- a/lib/debrid.js
+++ b/lib/debrid.js
@@ -3,8 +3,21 @@ async function request(url, opts) {
     ...opts,
     headers: { 'User-Agent': 'Flix-Finder/2.0', ...(opts?.headers || {}) }
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
+  if (res.status === 204) return null;
+  const text = await res.text();
+  const data = text ? (() => {
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      return text;
+    }
+  })() : null;
+  if (!res.ok) {
+    const detail = data?.error || data?.message || data?.detail;
+    const code = data?.error_code ? ` (${data.error_code})` : '';
+    throw new Error(detail ? `${detail}${code}` : `HTTP ${res.status}`);
+  }
+  return data;
 }
 
 function sleep(ms) {
@@ -14,14 +27,19 @@ function sleep(ms) {
 async function realDebrid(magnet, token) {
   const base = 'https://api.real-debrid.com/rest/1.0';
   const auth = { Authorization: `Bearer ${token}` };
+  const withAuthToken = (path) => {
+    const url = new URL(`${base}${path}`);
+    url.searchParams.set('auth_token', token);
+    return url.toString();
+  };
 
-  const add = await request(`${base}/torrents/addMagnet`, {
+  const add = await request(withAuthToken('/torrents/addMagnet'), {
     method: 'POST',
     headers: { ...auth, 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({ magnet })
   });
 
-  await request(`${base}/torrents/selectFiles/${add.id}`, {
+  await request(withAuthToken(`/torrents/selectFiles/${add.id}`), {
     method: 'POST',
     headers: { ...auth, 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({ files: 'all' })
@@ -29,18 +47,29 @@ async function realDebrid(magnet, token) {
 
   let info;
   for (let i = 0; i < 10; i++) {
-    info = await request(`${base}/torrents/info/${add.id}`, { headers: auth });
-    if (info.status === 'downloaded' && info.links?.length) break;
+    info = await request(withAuthToken(`/torrents/info/${add.id}`), { headers: auth });
+    if (info.links?.length) break;
     if (info.status === 'error' || info.status === 'dead') throw new Error('Torrent failed');
     await sleep(1000);
   }
 
   if (!info?.links?.length) throw new Error('No links');
 
-  const dl = await request(`${base}/unrestrict/link`, {
+  let link = info.links[0];
+  if (Array.isArray(info.files) && info.files.length) {
+    const selectedFiles = info.files.filter(file => file.selected !== 0);
+    const files = selectedFiles.length ? selectedFiles : info.files;
+    const largest = files.reduce((max, file) => (file.bytes > max.bytes ? file : max), files[0]);
+    const selectedIndex = (selectedFiles.length ? selectedFiles : info.files).indexOf(largest);
+    if (selectedIndex >= 0 && info.links[selectedIndex]) {
+      link = info.links[selectedIndex];
+    }
+  }
+
+  const dl = await request(withAuthToken('/unrestrict/link'), {
     method: 'POST',
     headers: { ...auth, 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({ link: info.links[0] })
+    body: new URLSearchParams({ link })
   });
 
   return { url: dl.download, title: info.filename || dl.filename, name: 'RD' };
@@ -90,6 +119,7 @@ async function resolveDebridStreams(streams, config) {
   if (!resolver) return streams;
 
   const results = [];
+  const errors = [];
   for (const stream of streams) {
     try {
       // Convert infoHash to magnet link for debrid services
@@ -110,11 +140,24 @@ async function resolveDebridStreams(streams, config) {
         url: resolved.url
       });
     } catch (e) {
-      // skip failed
+      errors.push(e?.message || 'Debrid failed');
     }
   }
 
-  return results.length ? results : streams;
+  if (results.length) return results;
+  if (errors.length && streams.length) {
+    const first = streams[0];
+    const fallbackMagnet = first?.infoHash ? `magnet:?xt=urn:btih:${first.infoHash}` : first?.url;
+    return [
+      {
+        name: 'Flix-Finder',
+        title: `🟣 [RD:error] ${errors[0]}`,
+        url: fallbackMagnet || 'https://real-debrid.com'
+      },
+      ...streams
+    ];
+  }
+  return streams;
 }
 
 module.exports = { resolveDebridStreams };

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -28,6 +28,28 @@ async function fetchMeta(imdbId, type) {
 
 function parseConfig(query) {
   query = query || {};
+  const resolveDebridToken = (value) => {
+    const raw = String(value || '').trim();
+    if (!raw) return '';
+    if (!/manifest\.json$/i.test(raw)) return raw;
+    try {
+      const url = new URL(raw);
+      const parts = url.pathname.split('/').filter(Boolean);
+      const manifestIndex = parts.findIndex(part => part.toLowerCase() === 'manifest.json');
+      if (manifestIndex <= 0) return raw;
+      const encoded = parts[manifestIndex - 1];
+      const normalized = encoded
+        .replace(/-/g, '+')
+        .replace(/_/g, '/')
+        .padEnd(Math.ceil(encoded.length / 4) * 4, '=');
+      const decoded = Buffer.from(normalized, 'base64').toString('utf8');
+      const parsed = JSON.parse(decoded);
+      const nestedToken = String(parsed?.debridToken || '').trim();
+      return nestedToken || raw;
+    } catch {
+      return raw;
+    }
+  };
   const rawSources = query.sources;
   const normalizedSources = Array.isArray(rawSources)
     ? rawSources.map(source => String(source).toLowerCase().trim()).filter(Boolean)
@@ -36,7 +58,7 @@ function parseConfig(query) {
   return {
     quality: String(query.quality || 'any'),
     debridService: String(query.debrid || 'none').toLowerCase(),
-    debridToken: String(query.debridToken || '').trim(),
+    debridToken: resolveDebridToken(query.debridToken),
     include: String(query.include || '').split(',').map(s => s.trim()).filter(Boolean),
     exclude: String(query.exclude || '').split(',').map(s => s.trim()).filter(Boolean),
     maxResults: Math.max(parseInt(query.maxResults, 10) || 10, 0),
@@ -495,6 +517,5 @@ module.exports = {
   fetchExtResults: searchTorrents,
   filterStreams
 };
-
 
 


### PR DESCRIPTION
### Motivation
- URL/base64-encoded config strings and base64url variants were breaking JSON decoding and prevented nested manifest-based `debridToken` values from being resolved.
- Real‑Debrid interactions needed more robust HTTP handling and better selection/unrestrict logic so cached links are preferred and API error details are visible.
- When debrid resolution fails entirely the UI should surface the failure instead of silently falling back to only P2P links.

### Description
- Normalize and safely decode base64 config strings in `api/config-manifest.js` and `api/config-stream.js` by restoring spaces to `+`, converting base64url (`-`/`_`) to standard base64, and padding before decoding JSON via `Buffer.from(..., 'base64')` and `JSON.parse`.
- Add `resolveDebridToken` inside `lib/ext.js` and use it from `parseConfig` to detect `manifest.json` URLs, decode the previous path segment as base64, parse the nested manifest JSON, and return a nested `debridToken` when present.
- Harden `lib/debrid.js` `request` to handle `204` responses, parse plain-text responses into JSON when possible, and include API-provided error details in thrown errors.
- Add a `withAuthToken` helper and use it for Real‑Debrid endpoints, stop polling only when links are present (allow unrestricting before `downloaded`), choose the best file link (largest selected file) when creating the unrestrict request, and return `{ url, title, name }` consistently.
- In `resolveDebridStreams` collect debrid errors and, when no debrid links resolved, prepend a visible fallback stream entry named `Flix-Finder` with a title like `🟣 [RD:error] <message>` and a fallback magnet URL so failures are surfaced to the client.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982895f701883318ceed5ae9d49e470)