### PR TITLE
Add Nyaa as a configurable torrent source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Stremio addon for torrent streaming. Searches multiple torrent indexers and retu
 - TV torrents via EZTV API
 - Movie torrents via YTS API
 - Anime torrents via AnimeTosho
+- Torrents via Nyaa search
 - Movies and TV series support
 - Quality filtering (4K, 1080p, 720p)
 - Keyword filters (include/exclude)

--- a/lib/ext.js
+++ b/lib/ext.js
@@ -2,8 +2,9 @@ const KNABEN_API = 'https://api.knaben.org/v1';
 const EZTV_API = 'https://eztvx.to/api';
 const YTS_API = 'https://yts.bz/api/v2';
 const ANIMETOSHO_SEARCH = 'https://animetosho.org/search';
+const NYAA_SEARCH = 'https://nyaa.si/';
 const CINEMETA_API = 'https://v3-cinemeta.strem.io/meta';
-const ALL_SOURCES = ['knaben', 'eztv', 'yts', 'animetosho'];
+const ALL_SOURCES = ['knaben', 'eztv', 'yts', 'animetosho', 'nyaa'];
 
 async function fetchWithTimeout(url, options = {}, timeoutMs = 8000) {
   const controller = new AbortController();
@@ -419,6 +420,72 @@ async function searchAnimetosho(query) {
   }
 }
 
+async function searchNyaa(query) {
+  if (!query) return [];
+
+  try {
+    const url = new URL(NYAA_SEARCH);
+    const normalizedQuery = query.trim().replace(/\s+/g, ' ');
+    if (!normalizedQuery) return [];
+    url.searchParams.set('q', normalizedQuery);
+    url.searchParams.set('f', '0');
+    url.searchParams.set('c', '0_0');
+
+    const res = await fetch(url.toString(), {
+      headers: { 'User-Agent': 'Flix-Finder/2.0' }
+    });
+    if (!res.ok) return [];
+    const html = await res.text();
+
+    const streams = [];
+    const seen = new Set();
+
+    const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+    const magnetRegex = /href="(magnet:\?xt=urn:btih:(?:[a-fA-F0-9]{40}|[A-Z2-7]{32})[^"\s<]*)"/i;
+    const titleRegex = /<a[^>]+href="\/view\/\d+"[^>]*>([\s\S]*?)<\/a>/i;
+    const sizeRegex = /<td[^>]+class="[^\"]*text-center[^\"]*"[^>]*>(\d+(?:\.\d+)?\s*(?:TB|GB|MB|KB|TiB|GiB|MiB|KiB))<\/td>/i;
+    const seedsRegex = /<td[^>]+class="[^\"]*text-center[^\"]*"[^>]*>(\d+)<\/td>\s*<td[^>]+class="[^\"]*text-center[^\"]*"[^>]*>\d+<\/td>\s*<td[^>]+class="[^\"]*text-center[^\"]*"[^>]*>\d+<\/td>/i;
+
+    const cleanText = (value) =>
+      decodeHtmlEntities(value)
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    let rowMatch;
+    while ((rowMatch = rowRegex.exec(html)) !== null) {
+      const row = rowMatch[1];
+      const magnetMatch = row.match(magnetRegex);
+      if (!magnetMatch) continue;
+
+      const infoHash = extractInfoHash(decodeHtmlEntities(magnetMatch[1]));
+      if (!infoHash || seen.has(infoHash)) continue;
+
+      const titleMatch = row.match(titleRegex);
+      const title = titleMatch ? cleanText(titleMatch[1]) : '';
+      if (!title) continue;
+
+      seen.add(infoHash);
+
+      const sizeMatch = row.match(sizeRegex);
+      const seedsMatch = row.match(seedsRegex);
+      const size = sizeMatch ? cleanText(sizeMatch[1]) : '';
+      const seeds = seedsMatch ? seedsMatch[1] : '';
+      const meta = [size, seeds ? `S:${seeds}` : null, 'Nyaa'].filter(Boolean).join(' | ');
+
+      streams.push({
+        name: 'Flix-Finder',
+        title: `${title}\n${meta}`,
+        infoHash
+      });
+    }
+
+    return streams;
+  } catch (e) {
+    return [];
+  }
+}
+
 function uniqueByInfoHash(streams) {
   const seen = new Set();
   return streams.filter(stream => {
@@ -496,13 +563,14 @@ async function searchTorrents(id, options) {
     type === 'movie' && sources.includes('yts') ? searchYts(id) : []
   ]);
 
-  const animetoshoResults = sources.includes('animetosho')
-    ? await searchAnimetosho(query || baseTitle)
-    : [];
+  const [animetoshoResults, nyaaResults] = await Promise.all([
+    sources.includes('animetosho') ? searchAnimetosho(query || baseTitle) : [],
+    sources.includes('nyaa') ? searchNyaa(query || baseTitle) : []
+  ]);
 
   const merged = type === 'movie'
-    ? mergeRoundRobin([knabenResults, ytsResults, animetoshoResults])
-    : mergeRoundRobin([knabenResults, eztvResults, animetoshoResults]);
+    ? mergeRoundRobin([knabenResults, ytsResults, animetoshoResults, nyaaResults])
+    : mergeRoundRobin([knabenResults, eztvResults, animetoshoResults, nyaaResults]);
   const unique = uniqueByInfoHash(merged);
   if (type === 'series' && parsed.season != null && parsed.episode != null) {
     return unique.filter(stream => isExactEpisodeMatch(stream.title, parsed.season, parsed.episode));
@@ -517,5 +585,4 @@ module.exports = {
   fetchExtResults: searchTorrents,
   filterStreams
 };
-
 

--- a/public/configure.html
+++ b/public/configure.html
@@ -247,6 +247,10 @@
           <input type="checkbox" name="sources" value="animetosho" checked />
           AnimeTosho
         </label>
+        <label class="checkbox-item">
+          <input type="checkbox" name="sources" value="nyaa" checked />
+          Nyaa
+        </label>
       </div>
 
       <label for="debridToken">API Token</label>


### PR DESCRIPTION
### Motivation
- Provide search results from `nyaa.si` so users can find additional torrents (especially anime) using the project's existing query format.
- Make Nyaa selectable via the configuration UI so users can enable/disable it like other sources.
- Merge Nyaa results with existing sources so results are interleaved with the current round-robin ordering.

### Description
- Added `NYAA_SEARCH` and appended `'nyaa'` to `ALL_SOURCES` in `lib/ext.js` to include Nyaa in default sources and config parsing.
- Implemented `searchNyaa(query)` in `lib/ext.js` which queries `https://nyaa.si/` using the `?q=...&f=0&c=0_0` pattern, parses rows for magnet links, extracts infohash, title, size and seeders, and returns stream objects.
- Integrated Nyaa into `searchTorrents` by fetching `searchNyaa` alongside other sources and including its results in the `mergeRoundRobin` merge for movies and series.
- Exposed Nyaa in the configuration page by adding a checked `Nyaa` checkbox to `public/configure.html`, and documented the new source in `README.md`.

### Testing
- Ran `node -e "require('./lib/ext'); console.log('ok')"` which succeeded and loaded the module without syntax/runtime errors.
- Verified `parseConfig` behavior with `node` (e.g. `parseConfig({}).sources` and `parseConfig({ sources: 'knaben,nyaa' }).sources`) which returned expected source lists including `nyaa`.
- Executed the existing `test.js` which failed in this environment due to external network `ENETUNREACH` when calling the Cinemeta endpoint, preventing full end-to-end verification of remote fetches.
- Attempted a Playwright screenshot of the configure page which failed in this environment due to Chromium launch errors (SIGSEGV), so no visual artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698848b6d3e083319a01562246a835db)