### PR TITLE
Fix configured stream endpoint module crash

### DIFF
--- a/api/config-stream.js
+++ b/api/config-stream.js
@@ -17,26 +17,6 @@ function decodeConfig(configStr) {
   }
 }
 
-function withSupportLink(streams, maxResults) {
-  const supportStream = {
-    name: 'Flix-Finder',
-    title: '🤝 Support Flix-Finder\n☕ Buy me a coffee on Ko-fi',
-    url: SUPPORT_URL,
-    externalUrl: SUPPORT_URL
-  };
-
-  if (!Number.isFinite(maxResults) || maxResults <= 1) {
-    return [...streams, supportStream];
-  }
-
-  const insertAt = Math.min(Math.max(maxResults - 1, 0), streams.length);
-  return [
-    ...streams.slice(0, insertAt),
-    supportStream,
-    ...streams.slice(insertAt)
-  ];
-}
-
 module.exports = async (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
### Motivation
- The configured stream endpoint declared a local `withSupportLink` function that duplicated the imported helper, causing a parse-time error which could prevent the addon from loading streams.

### Description
- Remove the duplicate local `withSupportLink` declaration from `api/config-stream.js` so the endpoint uses the shared helper imported from `lib/support`.

### Testing
- Loaded the configured stream handler with `node -e "require('./api/config-stream'); console.log('config-stream ok')"` and it completed successfully.
- Loaded all core handlers and libraries with `node -e "require('./api/manifest'); require('./api/config-manifest'); require('./api/config-stream'); require('./api/stream/[type]/[id]'); require('./lib/ext'); require('./lib/debrid'); require('./lib/support'); console.log('all modules load')"` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cebae5d98832ca9cb95dff3a4db63)